### PR TITLE
Fix nomad deploy and extend to web and publishing

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,6 @@
 extensions:
   health_check:
+    endpoint: "localhost:13133"
   pprof:
     endpoint: 0.0.0.0:1777
 
@@ -7,7 +8,7 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:12850
+        endpoint: 0.0.0.0:4317
 
 processors:
   batch:
@@ -16,9 +17,11 @@ exporters:
   logging:
     loglevel: debug
   awsxray:
-    region: 'eu-west-2'
+    region: "eu-west-2"
   awsemf:
-    region: 'eu-west-2'
+    region: "eu-west-2"
+  prometheus:
+    endpoint: "0.0.0.0:8889"
 
 service:
   pipelines:
@@ -27,9 +30,9 @@ service:
       exporters: [awsxray]
     metrics:
       receivers: [otlp]
-      exporters: [awsemf]
+      exporters: [prometheus, awsemf]
 
-  extensions: [pprof]
+  extensions: [health_check, pprof]
   telemetry:
     logs:
       level: debug

--- a/dp-adot-collector.nomad
+++ b/dp-adot-collector.nomad
@@ -3,13 +3,13 @@ job "dp-adot-collector" {
   region      = "eu"
   type        = "service"
 
-  constraint {
-    attribute = "${node.class}"
-    value     = "management"
-  }
-
   group "management" {
-    count = "1"
+    count = "{{MANAGEMENT_TASK_COUNT}}"
+
+    constraint {
+      attribute = "${node.class}"
+      value     = "management"
+    }
 
     restart {
       attempts = 3
@@ -18,51 +18,267 @@ job "dp-adot-collector" {
       mode     = "delay"
     }
 
+    network {
+      port "grpc" {
+        to = 4317
+      }
+      port "prometheus" {
+        to = 8889
+      }
+      port "health" {
+        to = 13133
+      }
+    }
+
     task "dp-adot-collector" {
       driver = "docker"
 
-      artifact {
-        source = "s3::https://s3-eu-west-2.amazonaws.com/{{DEPLOYMENT_BUCKET}}/dp-adot-collector/{{REVISION}}.tar.gz"
-      }
-
       config {
-        command = "${NOMAD_TASK_DIR}/start-task"
-
-        args = ["./dp-adot-collector"]
-
         image = "{{ECR_URL}}:concourse-{{REVISION}}"
+        ports = ["grpc","health","prometheus"]
       }
 
       service {
-        name = "dp-adot-collector"
-        port = "http"
-        tags = ["management"]
+        name = "dp-adot-collector-grpc"
+        port = "grpc"
+        tags = ["management","otel-collector"]
+
         check {
           type     = "http"
+          port     = "health"
           path     = "/health"
           interval = "10s"
           timeout  = "2s"
         }
       }
 
-      resources {
-        cpu    = "500"
-        memory = "512"
+      service {
+        name = "dp-adot-collector-prometheus"
+        port = "prometheus"
+        tags = ["management","otel-collector"]
 
-        network {
-          port "http" {}
+        check {
+          type     = "http"
+          port     = "health"
+          path     = "/metrics"
+          interval = "1m"
+          timeout  = "2s"
         }
       }
 
+      resources {
+        cpu    = "{{MANAGEMENT_RESOURCE_CPU}}"
+        memory = "{{MANAGEMENT_RESOURCE_MEM}}"
+      }
+
       template {
-        source      = "${NOMAD_TASK_DIR}/vars-template"
-        destination = "${NOMAD_TASK_DIR}/vars"
-      
+        data = <<EOH
+        # Configs based on environment (e.g. export BIND_ADDR=":{{ env "NOMAD_PORT_http" }}")
+        # or static (e.g. export BIND_ADDR=":8080")
+
+        # Secret configs read from vault
+        {{ with (secret (print "secret/" (env "NOMAD_TASK_NAME"))) }}
+        {{ range $key, $value := .Data }}
+        export {{ $key }}="{{ $value }}"
+        {{ end }}
+        {{ end }}
+        EOH
+
+        destination = "secrets/app.env"
+        env         = true
+        splay       = "1m"
+        change_mode = "restart"
       }
 
       vault {
         policies = ["dp-adot-collector"]
       }
-
     }
   }
+
+  group "web" {
+    count = "{{WEB_TASK_COUNT}}"
+
+    constraint {
+      attribute = "${node.class}"
+      value     = "web"
+    }
+
+    restart {
+      attempts = 3
+      delay    = "15s"
+      interval = "1m"
+      mode     = "delay"
+    }
+
+    network {
+      port "grpc" {
+        to = 4317
+      }
+      port "prometheus" {
+        to = 8889
+      }
+      port "health" {
+        to = 13133
+      }
+    }
+
+    task "dp-adot-collector" {
+      driver = "docker"
+
+      config {
+        image = "{{ECR_URL}}:concourse-{{REVISION}}"
+        ports = ["grpc","health","prometheus"]
+      }
+
+      service {
+        name = "dp-adot-collector-grpc"
+        port = "grpc"
+        tags = ["web","otel-collector"]
+
+        check {
+          type     = "http"
+          port     = "health"
+          path     = "/health"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+
+      service {
+        name = "dp-adot-collector-prometheus"
+        port = "prometheus"
+        tags = ["web","otel-collector"]
+
+        check {
+          type     = "http"
+          port     = "health"
+          path     = "/metrics"
+          interval = "1m"
+          timeout  = "2s"
+        }
+      }
+
+      resources {
+        cpu    = "{{WEB_RESOURCE_CPU}}"
+        memory = "{{WEB_RESOURCE_MEM}}"
+      }
+
+      template {
+        data = <<EOH
+        # Configs based on environment (e.g. export BIND_ADDR=":{{ env "NOMAD_PORT_http" }}")
+        # or static (e.g. export BIND_ADDR=":8080")
+
+        # Secret configs read from vault
+        {{ with (secret (print "secret/" (env "NOMAD_TASK_NAME"))) }}
+        {{ range $key, $value := .Data }}
+        export {{ $key }}="{{ $value }}"
+        {{ end }}
+        {{ end }}
+        EOH
+
+        destination = "secrets/app.env"
+        env         = true
+        splay       = "1m"
+        change_mode = "restart"
+      }
+
+      vault {
+        policies = ["dp-adot-collector"]
+      }
+    }
+  }
+
+  group "publishing" {
+    count = "{{PUBLISHING_TASK_COUNT}}"
+
+    constraint {
+      attribute = "${node.class}"
+      value     = "publishing"
+    }
+
+    restart {
+      attempts = 3
+      delay    = "15s"
+      interval = "1m"
+      mode     = "delay"
+    }
+
+    network {
+      port "grpc" {
+        to = 4317
+      }
+      port "prometheus" {
+        to = 8889
+      }
+      port "health" {
+        to = 13133
+      }
+    }
+
+    task "dp-adot-collector" {
+      driver = "docker"
+
+      config {
+        image = "{{ECR_URL}}:concourse-{{REVISION}}"
+        ports = ["grpc","health","prometheus"]
+      }
+
+      service {
+        name = "dp-adot-collector-grpc"
+        port = "grpc"
+        tags = ["publishing","otel-collector"]
+
+        check {
+          type     = "http"
+          port     = "health"
+          path     = "/health"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+
+      service {
+        name = "dp-adot-collector-prometheus"
+        port = "prometheus"
+        tags = ["publishing","otel-collector"]
+
+        check {
+          type     = "http"
+          port     = "health"
+          path     = "/metrics"
+          interval = "1m"
+          timeout  = "2s"
+        }
+      }
+
+      resources {
+        cpu    = "{{PUBLISHING_RESOURCE_CPU}}"
+        memory = "{{PUBLISHING_RESOURCE_MEM}}"
+      }
+
+      template {
+        data = <<EOH
+        # Configs based on environment (e.g. export BIND_ADDR=":{{ env "NOMAD_PORT_http" }}")
+        # or static (e.g. export BIND_ADDR=":8080")
+
+        # Secret configs read from vault
+        {{ with (secret (print "secret/" (env "NOMAD_TASK_NAME"))) }}
+        {{ range $key, $value := .Data }}
+        export {{ $key }}="{{ $value }}"
+        {{ end }}
+        {{ end }}
+        EOH
+
+        destination = "secrets/app.env"
+        env         = true
+        splay       = "1m"
+        change_mode = "restart"
+      }
+
+      vault {
+        policies = ["dp-adot-collector"]
+      }
+    }
+  }
+}

--- a/dp-adot-collector.nomad
+++ b/dp-adot-collector.nomad
@@ -18,18 +18,6 @@ job "dp-adot-collector" {
       mode     = "delay"
     }
 
-    network {
-      port "grpc" {
-        to = 4317
-      }
-      port "prometheus" {
-        to = 8889
-      }
-      port "health" {
-        to = 13133
-      }
-    }
-
     task "dp-adot-collector" {
       driver = "docker"
 
@@ -69,6 +57,18 @@ job "dp-adot-collector" {
       resources {
         cpu    = "{{MANAGEMENT_RESOURCE_CPU}}"
         memory = "{{MANAGEMENT_RESOURCE_MEM}}"
+
+        network {
+          port "grpc" {
+            to = 4317
+          }
+          port "prometheus" {
+            to = 8889
+          }
+          port "health" {
+            to = 13133
+          }
+        }
       }
 
       template {
@@ -111,18 +111,6 @@ job "dp-adot-collector" {
       mode     = "delay"
     }
 
-    network {
-      port "grpc" {
-        to = 4317
-      }
-      port "prometheus" {
-        to = 8889
-      }
-      port "health" {
-        to = 13133
-      }
-    }
-
     task "dp-adot-collector" {
       driver = "docker"
 
@@ -162,6 +150,18 @@ job "dp-adot-collector" {
       resources {
         cpu    = "{{WEB_RESOURCE_CPU}}"
         memory = "{{WEB_RESOURCE_MEM}}"
+
+        network {
+          port "grpc" {
+            to = 4317
+          }
+          port "prometheus" {
+            to = 8889
+          }
+          port "health" {
+            to = 13133
+          }
+        }
       }
 
       template {
@@ -204,18 +204,6 @@ job "dp-adot-collector" {
       mode     = "delay"
     }
 
-    network {
-      port "grpc" {
-        to = 4317
-      }
-      port "prometheus" {
-        to = 8889
-      }
-      port "health" {
-        to = 13133
-      }
-    }
-
     task "dp-adot-collector" {
       driver = "docker"
 
@@ -255,6 +243,18 @@ job "dp-adot-collector" {
       resources {
         cpu    = "{{PUBLISHING_RESOURCE_CPU}}"
         memory = "{{PUBLISHING_RESOURCE_MEM}}"
+
+        network {
+          port "grpc" {
+            to = 4317
+          }
+          port "prometheus" {
+            to = 8889
+          }
+          port "health" {
+            to = 13133
+          }
+        }
       }
 
       template {


### PR DESCRIPTION
Update the nomad plan to:
* Fix the networking configuration
* Simplify the templating logic to remove need to download tar with environment variable template in it
* Enable variable scale of deployment per environment using configs from manifest
* Fix service registration and health checks

This change does not expose the `pprof` endpoint currently. If this is desired then a further change will be required.

The config was also updated to enable the prometheus exporter and specify the ports to ensure they will always match the nomad plan in future.