### PR TITLE
Remove unnecessary build input

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -9,7 +9,6 @@ image_resource:
 
 inputs:
   - name: dp-adot-collector
-  - name: dp-ci
 
 outputs:
   - name: build


### PR DESCRIPTION
Remove the unused `dp-ci` build task input.