### PR TITLE
added rule for later versions of OT

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -26,6 +26,7 @@ processors:
     traces:
       span:
         - 'attributes["http.user_agent"] == "Consul Health Check"'
+        - 'attributes["user_agent.original"] == "Consul Health Check"'
   memory_limiter:
     check_interval: 1s
     limit_percentage: 80


### PR DESCRIPTION
**What**
Filter rule to exclude health check agents is not working in sandbox. This may be falling foul of a schema change in later versions of the OT collector codebase. Added rule to exclude both combinations.