### PR TITLE
Use a static port for prometheus exporter

### DIFF
--- a/dp-adot-collector.nomad
+++ b/dp-adot-collector.nomad
@@ -23,7 +23,8 @@ job "dp-adot-collector" {
         to = 4317
       }
       port "prometheus" {
-        to = 8889
+        static = 8889
+        to     = 8889
       }
       port "health" {
         to = 13133
@@ -115,7 +116,8 @@ job "dp-adot-collector" {
         to = 4317
       }
       port "prometheus" {
-        to = 8889
+        static = 8889
+        to     = 8889
       }
       port "health" {
         to = 13133


### PR DESCRIPTION
The prometheus exporter endpoint was using a dynamic port. Due to our deployment that would have required too many ports to be opened up to allow the prometheus scraping with the current deployment. Restricting this to a static port will limit us to running one instance of the otel collector per instance, but that should be ok.