### PR TITLE
Fix load balancer deployment

### DIFF
--- a/dp-adot-collector-lb.nomad
+++ b/dp-adot-collector-lb.nomad
@@ -1,14 +1,15 @@
 job "dp-adot-collector-lb" {
   datacenters = ["eu-west-2"]
   region      = "eu"
-  type        = "system"
+  type        = "service"
   priority    = 90
 
-  meta {
-    job_type = "system"
+  constraint {
+    distinct_hosts = true
   }
 
   group "web" {
+    count = "{{WEB_TASK_COUNT}}"
 
     constraint {
       attribute = "${node.class}"
@@ -86,6 +87,7 @@ job "dp-adot-collector-lb" {
   }
 
   group "publishing" {
+    count = "{{PUBLISHING_TASK_COUNT}}"
 
     constraint {
       attribute = "${node.class}"

--- a/dp-adot-collector-lb.nomad
+++ b/dp-adot-collector-lb.nomad
@@ -2,6 +2,7 @@ job "dp-adot-collector-lb" {
   datacenters = ["eu-west-2"]
   region      = "eu"
   type        = "system"
+  priority    = 90
 
   meta {
     job_type = "system"
@@ -11,7 +12,8 @@ job "dp-adot-collector-lb" {
 
     constraint {
       attribute = "${node.class}"
-      value     = "web"
+      operator  = "regexp"
+      value     = "web.*"
     }
 
     restart {
@@ -23,7 +25,8 @@ job "dp-adot-collector-lb" {
 
     network {
       port "grpc" {
-        to = 4317
+        static = 4317
+        to     = 4317
       }
       port "health" {
         to = 13133
@@ -44,9 +47,7 @@ job "dp-adot-collector-lb" {
       }
     }
 
-
-
-    task "dp-adot-collector-lb" {
+    task "dp-adot-collector-lb-web" {
       driver = "docker"
 
       config {
@@ -79,7 +80,7 @@ job "dp-adot-collector-lb" {
       }
 
       vault {
-        policies = ["dp-adot-collector-lb"]
+        policies = ["dp-adot-collector-lb-web"]
       }
     }
   }
@@ -88,7 +89,8 @@ job "dp-adot-collector-lb" {
 
     constraint {
       attribute = "${node.class}"
-      value     = "publishing"
+      operator  = "regexp"
+      value     = "publishing.*"
     }
 
     restart {
@@ -100,7 +102,8 @@ job "dp-adot-collector-lb" {
 
     network {
       port "grpc" {
-        to = 4317
+        static = 4317
+        to     = 4317
       }
       port "health" {
         to = 13133
@@ -121,7 +124,7 @@ job "dp-adot-collector-lb" {
       }
     }
 
-    task "dp-adot-collector-lb" {
+    task "dp-adot-collector-lb-publishing" {
       driver = "docker"
 
       config {
@@ -154,7 +157,7 @@ job "dp-adot-collector-lb" {
       }
 
       vault {
-        policies = ["dp-adot-collector-lb"]
+        policies = ["dp-adot-collector-lb-publishing"]
       }
     }
   }

--- a/dp-adot-collector.nomad
+++ b/dp-adot-collector.nomad
@@ -3,6 +3,10 @@ job "dp-adot-collector" {
   region      = "eu"
   type        = "service"
 
+  constraint {
+    distinct_hosts = true
+  }
+
   group "web" {
     count = "{{WEB_TASK_COUNT}}"
 
@@ -20,7 +24,8 @@ job "dp-adot-collector" {
 
     network {
       port "grpc" {
-        to = 9317
+        static = 9317
+        to     = 9317
       }
       port "prometheus" {
         static = 8889
@@ -113,7 +118,8 @@ job "dp-adot-collector" {
 
     network {
       port "grpc" {
-        to = 9317
+        static = 9317
+        to     = 9317
       }
       port "prometheus" {
         static = 8889


### PR DESCRIPTION
Addresses several nomad plan configuration issues:
* Fix errors due to vault policies and task groups specified in the nomad
  plan not matching the corresponding secrets and vault policies.
* Fix grpc port configurations so that they will be static, known ports.
  While this is not best practice for service type jobs, the unique host
  constraint will allow this to work and prevent the additional
  performance hit of the extra routing hops.
* Fix node constraint only deploying the load balancer to the
  autoscaling pool and not to web-1, web-2 and publishing-1.

Also includes a workaround for a known Nomad issue related to assigning static ports to system jobs https://github.com/hashicorp/nomad/issues/8934. The version of Nomad we are running has a bug whereby assigning static
ports to system jobs (which is a standard use case) was broken and resulted in an error stating that the port label can not be found. This is a known Nomad bug that can only be addressed by upgrading Nomad which we are unable to do at present (https://github.com/hashicorp/nomad/issues/8934). As such this workaround deploys the job as a `service` rather than `system` job meaning that we will need to manually configure the number of instances of the collector load balancer deployed to match the number of nomad client instances. This will only be a temporary workaround until the Kubernetes migration is completed.