### PR TITLE
Workaround for DNS discovery issues

### DIFF
--- a/dp-adot-collector.nomad
+++ b/dp-adot-collector.nomad
@@ -7,8 +7,8 @@ job "dp-adot-collector" {
     distinct_hosts = true
   }
 
-  group "web" {
-    count = "{{WEB_TASK_COUNT}}"
+  group "web-1" {
+    count = 1
 
     constraint {
       attribute = "${node.class}"
@@ -24,11 +24,10 @@ job "dp-adot-collector" {
 
     network {
       port "grpc" {
-        static = 9317
-        to     = 9317
+        to = 9317
       }
       port "prometheus" {
-        static = 8889
+        static = 8887
         to     = 8889
       }
       port "health" {
@@ -37,7 +36,7 @@ job "dp-adot-collector" {
     }
 
     service {
-      name = "dp-adot-collector-grpc-web"
+      name = "dp-adot-collector-grpc-web-1"
       port = "grpc"
       tags = ["web","otel-collector"]
 
@@ -101,8 +100,194 @@ job "dp-adot-collector" {
     }
   }
 
-  group "publishing" {
-    count = "{{PUBLISHING_TASK_COUNT}}"
+  group "web-2" {
+    count = 1
+
+    constraint {
+      attribute = "${node.class}"
+      value     = "web"
+    }
+
+    restart {
+      attempts = 3
+      delay    = "15s"
+      interval = "1m"
+      mode     = "delay"
+    }
+
+    network {
+      port "grpc" {
+        to = 9317
+      }
+      port "prometheus" {
+        static = 8888
+        to     = 8889
+      }
+      port "health" {
+        to = 13134
+      }
+    }
+
+    service {
+      name = "dp-adot-collector-grpc-web-2"
+      port = "grpc"
+      tags = ["web","otel-collector"]
+
+      check {
+        type     = "http"
+        port     = "health"
+        path     = "/health"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    service {
+      name = "dp-adot-collector-prometheus"
+      port = "prometheus"
+      tags = ["web","otel-collector"]
+
+      check {
+        type     = "http"
+        path     = "/metrics"
+        interval = "1m"
+        timeout  = "2s"
+      }
+    }
+
+    task "dp-adot-collector" {
+      driver = "docker"
+
+      config {
+        image = "{{ECR_URL}}:concourse-{{REVISION}}"
+        ports = ["grpc","health","prometheus"]
+      }
+
+      resources {
+        cpu    = "{{WEB_RESOURCE_CPU}}"
+        memory = "{{WEB_RESOURCE_MEM}}"
+      }
+
+      template {
+        data = <<EOH
+        # Configs based on environment (e.g. export BIND_ADDR=":{{ env "NOMAD_PORT_http" }}")
+        # or static (e.g. export BIND_ADDR=":8080")
+
+        # Secret configs read from vault
+        {{ with (secret (print "secret/" (env "NOMAD_TASK_NAME"))) }}
+        {{ range $key, $value := .Data }}
+        export {{ $key }}="{{ $value }}"
+        {{ end }}
+        {{ end }}
+        EOH
+
+        destination = "secrets/app.env"
+        env         = true
+        splay       = "1m"
+        change_mode = "restart"
+      }
+
+      vault {
+        policies = ["dp-adot-collector"]
+      }
+    }
+  }
+
+  group "web-3" {
+    count = 1
+
+    constraint {
+      attribute = "${node.class}"
+      value     = "web"
+    }
+
+    restart {
+      attempts = 3
+      delay    = "15s"
+      interval = "1m"
+      mode     = "delay"
+    }
+
+    network {
+      port "grpc" {
+        to = 9317
+      }
+      port "prometheus" {
+        static = 8889
+        to     = 8889
+      }
+      port "health" {
+        to = 13134
+      }
+    }
+
+    service {
+      name = "dp-adot-collector-grpc-web-3"
+      port = "grpc"
+      tags = ["web","otel-collector"]
+
+      check {
+        type     = "http"
+        port     = "health"
+        path     = "/health"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    service {
+      name = "dp-adot-collector-prometheus"
+      port = "prometheus"
+      tags = ["web","otel-collector"]
+
+      check {
+        type     = "http"
+        path     = "/metrics"
+        interval = "1m"
+        timeout  = "2s"
+      }
+    }
+
+    task "dp-adot-collector" {
+      driver = "docker"
+
+      config {
+        image = "{{ECR_URL}}:concourse-{{REVISION}}"
+        ports = ["grpc","health","prometheus"]
+      }
+
+      resources {
+        cpu    = "{{WEB_RESOURCE_CPU}}"
+        memory = "{{WEB_RESOURCE_MEM}}"
+      }
+
+      template {
+        data = <<EOH
+        # Configs based on environment (e.g. export BIND_ADDR=":{{ env "NOMAD_PORT_http" }}")
+        # or static (e.g. export BIND_ADDR=":8080")
+
+        # Secret configs read from vault
+        {{ with (secret (print "secret/" (env "NOMAD_TASK_NAME"))) }}
+        {{ range $key, $value := .Data }}
+        export {{ $key }}="{{ $value }}"
+        {{ end }}
+        {{ end }}
+        EOH
+
+        destination = "secrets/app.env"
+        env         = true
+        splay       = "1m"
+        change_mode = "restart"
+      }
+
+      vault {
+        policies = ["dp-adot-collector"]
+      }
+    }
+  }
+
+  group "publishing-1" {
+    count = 1
 
     constraint {
       attribute = "${node.class}"
@@ -118,8 +303,193 @@ job "dp-adot-collector" {
 
     network {
       port "grpc" {
-        static = 9317
-        to     = 9317
+        to = 9317
+      }
+      port "prometheus" {
+        static = 8887
+        to     = 8889
+      }
+      port "health" {
+        to = 13134
+      }
+    }
+
+    service {
+      name = "dp-adot-collector-grpc-publishing-1"
+      port = "grpc"
+      tags = ["publishing","otel-collector"]
+
+      check {
+        type     = "http"
+        port     = "health"
+        path     = "/health"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    service {
+      name = "dp-adot-collector-prometheus"
+      port = "prometheus"
+      tags = ["publishing","otel-collector"]
+
+      check {
+        type     = "http"
+        path     = "/metrics"
+        interval = "1m"
+        timeout  = "2s"
+      }
+    }
+
+    task "dp-adot-collector" {
+      driver = "docker"
+
+      config {
+        image = "{{ECR_URL}}:concourse-{{REVISION}}"
+        ports = ["grpc","health","prometheus"]
+      }
+
+      resources {
+        cpu    = "{{PUBLISHING_RESOURCE_CPU}}"
+        memory = "{{PUBLISHING_RESOURCE_MEM}}"
+      }
+
+      template {
+        data = <<EOH
+        # Configs based on environment (e.g. export BIND_ADDR=":{{ env "NOMAD_PORT_http" }}")
+        # or static (e.g. export BIND_ADDR=":8080")
+
+        # Secret configs read from vault
+        {{ with (secret (print "secret/" (env "NOMAD_TASK_NAME"))) }}
+        {{ range $key, $value := .Data }}
+        export {{ $key }}="{{ $value }}"
+        {{ end }}
+        {{ end }}
+        EOH
+
+        destination = "secrets/app.env"
+        env         = true
+        splay       = "1m"
+        change_mode = "restart"
+      }
+
+      vault {
+        policies = ["dp-adot-collector"]
+      }
+    }
+  }
+
+  group "publishing-2" {
+    count = 1
+
+    constraint {
+      attribute = "${node.class}"
+      value     = "publishing"
+    }
+
+    restart {
+      attempts = 3
+      delay    = "15s"
+      interval = "1m"
+      mode     = "delay"
+    }
+
+    network {
+      port "grpc" {
+        to = 9317
+      }
+      port "prometheus" {
+        static = 8888
+        to     = 8889
+      }
+      port "health" {
+        to = 13134
+      }
+    }
+
+    service {
+      name = "dp-adot-collector-grpc-publishing-2"
+      port = "grpc"
+      tags = ["publishing","otel-collector"]
+
+      check {
+        type     = "http"
+        port     = "health"
+        path     = "/health"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    service {
+      name = "dp-adot-collector-prometheus"
+      port = "prometheus"
+      tags = ["publishing","otel-collector"]
+
+      check {
+        type     = "http"
+        path     = "/metrics"
+        interval = "1m"
+        timeout  = "2s"
+      }
+    }
+
+    task "dp-adot-collector" {
+      driver = "docker"
+
+      config {
+        image = "{{ECR_URL}}:concourse-{{REVISION}}"
+        ports = ["grpc","health","prometheus"]
+      }
+
+      resources {
+        cpu    = "{{PUBLISHING_RESOURCE_CPU}}"
+        memory = "{{PUBLISHING_RESOURCE_MEM}}"
+      }
+
+      template {
+        data = <<EOH
+        # Configs based on environment (e.g. export BIND_ADDR=":{{ env "NOMAD_PORT_http" }}")
+        # or static (e.g. export BIND_ADDR=":8080")
+
+        # Secret configs read from vault
+        {{ with (secret (print "secret/" (env "NOMAD_TASK_NAME"))) }}
+        {{ range $key, $value := .Data }}
+        export {{ $key }}="{{ $value }}"
+        {{ end }}
+        {{ end }}
+        EOH
+
+        destination = "secrets/app.env"
+        env         = true
+        splay       = "1m"
+        change_mode = "restart"
+      }
+
+      vault {
+        policies = ["dp-adot-collector"]
+      }
+    }
+  }
+
+  group "publishing-3" {
+    count = 1
+
+    constraint {
+      attribute = "${node.class}"
+      value     = "publishing"
+    }
+
+    restart {
+      attempts = 3
+      delay    = "15s"
+      interval = "1m"
+      mode     = "delay"
+    }
+
+    network {
+      port "grpc" {
+        to = 9317
       }
       port "prometheus" {
         static = 8889
@@ -131,7 +501,7 @@ job "dp-adot-collector" {
     }
 
     service {
-      name = "dp-adot-collector-grpc-publishing"
+      name = "dp-adot-collector-grpc-publishing-3"
       port = "grpc"
       tags = ["publishing","otel-collector"]
 


### PR DESCRIPTION
There was an issue with the DNS service discovery and the docker bridge networking that we can not work through in the current timescales. This is a temporary solution to allow us to run multiple copies of the aggregators. While this approach makes it much harder to scale the aggregators out if needed, it is not expected to live long as the EKS work will replace this shortly anyway.