### PR TITLE
added lb processor to traces exporter pipeline

### DIFF
--- a/config-lb.yml
+++ b/config-lb.yml
@@ -39,7 +39,7 @@ service:
     traces:
       receivers: [otlp]
       exporters: [logging]
-      processors: [memory_limiter, filter/excludeHealthCheck]
+      processors: [memory_limiter, filter/excludeHealthCheck, loadbalancing]
     metrics:
       receivers: [otlp]
       exporters: [logging,loadbalancing]


### PR DESCRIPTION
Exporter was missing traces loadbalancing, so only metrics were being pushed