### PR TITLE
put tail_sampling back in processors

### DIFF
--- a/config-aggregator.yml
+++ b/config-aggregator.yml
@@ -39,7 +39,7 @@ service:
     traces:
       receivers: [otlp]
       exporters: [awsxray, logging]
-      processors: [memory_limiter]
+      processors: [memory_limiter, tail_sampling]
     metrics:
       receivers: [otlp]
       exporters: [prometheus]

--- a/config-aggregator.yml
+++ b/config-aggregator.yml
@@ -26,7 +26,7 @@ processors:
   
 exporters:
   logging:
-    loglevel: debug
+    loglevel: warn
   awsxray:
     region: "eu-west-2"
   awsemf:
@@ -48,4 +48,4 @@ service:
 
   telemetry:
     logs:
-      level: debug
+      level: warn

--- a/config-lb.yml
+++ b/config-lb.yml
@@ -22,7 +22,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    loglevel: warn
   loadbalancing:
     protocol:
       otlp:
@@ -48,4 +48,4 @@ service:
 
   telemetry:
     logs:
-      level: debug
+      level: warn


### PR DESCRIPTION
This PR restores the sampling config so only 10% of successful transactions are written to XRay (to keep XRay costs down).

This will need implementing before the release PR for staging