### PR TITLE
Ensure collector deployments spread over availability zones

### DIFF
--- a/dp-adot-collector.nomad
+++ b/dp-adot-collector.nomad
@@ -3,8 +3,15 @@ job "dp-adot-collector" {
   region      = "eu"
   type        = "service"
 
-  constraint {
-    distinct_hosts = true
+  spread {
+    attribute = "${node.unique.id}"
+    weight    = 100
+    # with `target` omitted, Nomad will spread allocations evenly across all values of the attribute.
+  }
+  spread {
+    attribute = "${attr.platform.aws.placement.availability-zone}"
+    weight    = 100
+    # with `target` omitted, Nomad will spread allocations evenly across all values of the attribute.
   }
 
   group "web-1" {


### PR DESCRIPTION
It has been observed that the following are not spread over 3 availability zones:

Processing app :  dp-adot-collector-grpc-publishing-1
   dp-adot-collector-grpc-publishing-1,ip-10-30-138-202,eu-west-2b
Processing app :  dp-adot-collector-grpc-publishing-2
   dp-adot-collector-grpc-publishing-2,ip-10-30-139-66,eu-west-2c
Processing app :  dp-adot-collector-grpc-publishing-3
   dp-adot-collector-grpc-publishing-3,ip-10-30-138-141,eu-west-2b

Processing app :  dp-adot-collector-prometheus
   dp-adot-collector-prometheus,ip-10-30-138-141,eu-west-2b
   dp-adot-collector-prometheus,ip-10-30-138-202,eu-west-2b
   dp-adot-collector-prometheus,ip-10-30-139-66,eu-west-2c

This adjustment should fix things.